### PR TITLE
west: spdx: Fix undefined reference to pkg.targetBuildFile

### DIFF
--- a/scripts/west_commands/zspdx/walker.py
+++ b/scripts/west_commands/zspdx/walker.py
@@ -605,6 +605,9 @@ class Walker:
             if depAbspath == "":
                 continue
 
+            if pkg.targetBuildFile is None:
+                log.wrn(f'skipping STATIC_LINK for empty {pkg.cfg.name} target build file')
+                continue
             # create relationship data between build files
             rd = RelationshipData()
             rd.ownerType = RelationshipDataElementType.FILENAME


### PR DESCRIPTION
This commit fixes a python exception when generating the SBOM with the west spdx command:
    AttributeError: 'NoneType' object has no attribute 'abspath'

The problem occurs when addBuildFile() executes on a zephyr module library that is empty and contains no source files. The build still generates library build commands to track the dependencies, but the library .a file is never created. The SPDX generation parses the build commands in order to create the build.spdx SBOM even though the artifacts do not exist. When addBuildFile() exits early with a return of None, it skips assigning the pkg.targetBuildFile a valid File object. Later when walkTargets() calls collectTargetDependencies() with the pkg as the 3rd argument, it eventually goes to create the relationship data between build files and references the pkg.targetBuildFile.abspath which is not valid since pkg.targetBuildFile was never assigned, and an AttributeError exception is thrown.

This commit fixes the problem in a minimally intrusive manner by simply skipping the creation of the relationship data between the build files at the end of collectTargetDependencies() in the case when the pkg.targetBuildFile was never assigned a valid value because the artifact path pointed to a non-existent file.